### PR TITLE
[CI] suppress error message of copying CNAME

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 script:
  - gulp
  - /snap/bin/hugo
- - cp CNAME public/
+ - cp CNAME public/ 2>/dev/null
 
 cache:
   directories:


### PR DESCRIPTION
Useful in forks where CNAME is deleted.